### PR TITLE
Return `find_references` results to caller

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -861,22 +861,26 @@ function M.goto_type_definition() return goto_definition('typeDefinition') end
 function M.goto_implementation() return goto_definition('implementation') end
 
 ---
--- Searches for project references to the current symbol and prints them.
+-- Searches for project references to the current symbol and both prints and returns them.
 -- @name find_references
-function M.find_references()
+-- @param no_print Optional, if `true` then no `ui._print` occurs.
+function M.find_references(no_print)
   local server = servers[buffer:get_lexer()]
   if server and buffer.filename and server.capabilities.referencesProvider then
     server:sync_buffer()
     local params = get_buffer_position_params()
     params.context = {includeDeclaration = true}
     local locations = server:request('textDocument/references', params)
-    if not locations or #locations == 0 then return end
-    for _, location in ipairs(locations) do
-      -- Print trailing ': ' to enable 'find in files' features like double-click, menu items,
-      -- Return keypress, etc.
-      ui._print(_L['[Files Found Buffer]'],
-        string.format('%s:%d: ', tofilename(location.uri), location.range.start.line))
+    if not locations or #locations == 0 then return nil end
+    if not no_print then
+      for _, location in ipairs(locations) do
+        -- Print trailing ': ' to enable 'find in files' features like double-click, menu items,
+        -- Return keypress, etc.
+        ui._print(_L['[Files Found Buffer]'],
+          string.format('%s:%d: ', tofilename(location.uri), location.range.start.line))
+      end
     end
+    return locations
   end
 end
 


### PR DESCRIPTION
This is so that users can optionally hook up another handling than `ui._print` to `find_references` results, yet the change is non-breaking. (So plain old normal `lsp.find_references()` calls see no change in behavior.)

(If you're curious, with this PR accepted, then in my case I'd later implement in my init.lua a `ui.dialogs.filteredlist`-based handling of find_references results. =)