### PR TITLE
Allow autocompletion labels containing spaces

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -844,7 +844,7 @@ textadept.editing.autocompleters.lsp = function()
 			label = symbol.filterText or symbol.label
 			snippets[label] = symbol.insertText
 		end
-		-- TODO: some labels can have spaces and need proper handling.
+		label = label:gsub(" ", "\u{00A0}") -- Replace spaces with non-breaking spaces, for them to not be separated.
 		if symbol.kind and xpm_map[symbol.kind] > 0 then
 			symbols[#symbols + 1] = string.format('%s?%d', label, xpm_map[symbol.kind]) -- TODO: auto_c_type_separator
 		else


### PR DESCRIPTION
Default separator is [space](https://orbitalquark.github.io/textadept/api.html#display-an-autocompletion-list:~:text=buffer.auto_c_separator,is%2032%20(%E2%80%98%20%E2%80%98).). This causes issues in LSPs in which there is a need for labels containing spaces, like the [zk](https://github.com/zk-org/zk) Zettelkasten lsp.