### PR TITLE
Workaround for zk language server

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -367,7 +367,7 @@ function Server.new(lang, root, cmd, init_options)
 				--	honorsChangeAnnotations = true
 				-- },
 				publishDiagnostics = {
-					--	relatedInformation = true,
+					relatedInformation = true,
 					--	tagSupport = {valueSet = {}},
 					--	versionSupport = true,
 					--	codeDescriptionSupport = true,


### PR DESCRIPTION
[zk](https://github.com/zk-org/zk) language server cannot accept an empty `publishDiagnostics` field. I have no single idea how this change would affect other language servers, nor whether textadept actually supports `textDocument/publishDiagnostics` capability's `relatedInformation` field.